### PR TITLE
chore: upgrade native SDK to 3.6.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## 3.6.1-rc.7-build.715(July 15th, 2022)
+VIDEO_SOURCE_BLOCK_NUM 32 ==> 64
 ## 3.6.1-rc.7-build.714(July 14th, 2022)
 VIDEO_SOURCE_BLOCK_NUM 10 ==> 32
 ## 3.6.1-rc.6-build.526(May 11th, 2022)

--- a/common/video_source_ipc.cpp
+++ b/common/video_source_ipc.cpp
@@ -12,7 +12,7 @@
 #include "ipc_shm.h"
 #include "node_log.h"
 
-#define VIDEO_SOURCE_BLOCK_NUM 32
+#define VIDEO_SOURCE_BLOCK_NUM 64
 #define VIDEO_SOURCE_BLOCK_SIZE 24576
 
 struct VideoSourceIpcMsgHeader {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora-electron-sdk",
-  "version": "3.6.1-rc.7-build.714",
+  "version": "3.6.1-rc.7-build.0715",
   "description": "agora-electron-sdk",
   "main": "js/AgoraSdk.js",
   "types": "types/AgoraSdk.d.ts",


### PR DESCRIPTION
chore: upgrade native SDK to 3.6.1.7