### PR TITLE
chore: upgrade native SDK to 3.6.1.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora-electron-sdk",
-  "version": "3.6.1-rc.7-build.0715",
+  "version": "3.6.1-rc.8-build.726",
   "description": "agora-electron-sdk",
   "main": "js/AgoraSdk.js",
   "types": "types/AgoraSdk.d.ts",
@@ -74,8 +74,8 @@
     "url": "git+https://github.com/AgoraIO-Community/Agora-RTC-SDK-for-Electron.git"
   },
   "agora_electron": {
-    "lib_sdk_win": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_v3.6.1.7_FULL_20220630_8521_215180.zip",
-    "lib_sdk_mac": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_v3.6.1.7_FULL_20220630_2715_215200.zip"
+    "lib_sdk_win": "http://192.168.99.149:8086/v3.6.1.8/AgoraSDK/Windows/testing/Agora_Native_SDK_for_Windows_v3.6.1.8_FULL_20220722_8662_222178.zip",
+    "lib_sdk_mac": "http://192.168.99.149:8086/v3.6.1.8/AgoraSDK/Mac/Agora_Native_SDK_for_Mac_v3.6.1.8_FULL_20220725_2804_222702.zip"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
chore: upgrade native SDK to 3.6.1.8