### PR TITLE
chore: upgrade native SDK to 3.6.1.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agora-electron-sdk",
-  "version": "3.6.1-rc.8-build.729",
+  "version": "3.6.1-rc.9-build.811",
   "description": "agora-electron-sdk",
   "main": "js/AgoraSdk.js",
   "types": "types/AgoraSdk.d.ts",
@@ -75,7 +75,8 @@
   },
   "agora_electron": {
     "lib_sdk_win": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_v3.6.1.8_FULL_20220726_8683_222954.zip",
-    "lib_sdk_mac": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_v3.6.1.8_FULL_20220726_2811_222960.zip"
+    "lib_sdk_mac": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Mac_v3.6.1.8_FULL_20220726_2811_222960.zip",
+    "lib_sdk_win64": "https://download.agora.io/sdk/release/Agora_Native_SDK_for_Windows_v3.6.1.9_FULL_20220810_8773_226487.zip"
   },
   "keywords": [
     "electron",


### PR DESCRIPTION
chore: upgrade native SDK to 3.6.1.9